### PR TITLE
Deleting vessels and flights, with tests

### DIFF
--- a/.github/workflows/deploy_to_server.yml
+++ b/.github/workflows/deploy_to_server.yml
@@ -30,4 +30,3 @@ jobs:
             cd /usr/share/uoarocketry-docker/docker
             sudo -n /usr/bin/docker-compose stop
             sudo -n /usr/bin/docker-compose up -d
-            sudo -n /usr/bin/docker image prune -f

--- a/app/controller/flight_controller.py
+++ b/app/controller/flight_controller.py
@@ -11,6 +11,7 @@ from app.services.data_access.user import get_user_by_unique_name
 from app.services.data_access.vessel import get_vessel 
 from app.controller.vessel_controller import vessels_controller
 from app.models.permissions import Permission
+from app.services.flight_service import FlightService
 
 
 flight_controller = APIRouter(
@@ -199,7 +200,8 @@ async def delete_flight_controller(user: AuthOptional, flight_id:UUID):
     if not has_flight_permission(flight, vessel, 'owner', user):
         raise HTTPException(403, 'You don\'t have the required permission to access the flight')
     
-    result = await bulk_delete_flights_by_ids([flight_id])
+    result = await FlightService.bulk_delete_flights_by_ids([flight_id])
+    
     if not result:
         raise HTTPException(500, 'Failed to delete flight')
     return 'success'

--- a/app/controller/flight_controller.py
+++ b/app/controller/flight_controller.py
@@ -6,7 +6,7 @@ from app.middleware.auth.requireAuth import AuthOptional, AuthRequired, user_opt
 from app.models.flight import Flight, FLIGHT_DEFAULT_HEAD_TIME, UpdateFlight
 from app.services.auth.jwt_user_info import UserInfo, get_socket_user_info
 from app.services.auth.permission_service import has_flight_permission, modify_flight_permission
-from app.services.data_access.flight import create_or_update_flight, delete_flight_by_id, get_all_flights_for_vessels, get_all_flights_for_vessels_by_name, get_flight
+from app.services.data_access.flight import bulk_delete_flights_by_ids, create_or_update_flight, get_all_flights_for_vessels, get_all_flights_for_vessels_by_name, get_flight
 from app.services.data_access.user import get_user_by_unique_name
 from app.services.data_access.vessel import get_vessel 
 from app.controller.vessel_controller import vessels_controller
@@ -199,6 +199,7 @@ async def delete_flight_controller(user: AuthOptional, flight_id:UUID):
     if not has_flight_permission(flight, vessel, 'owner', user):
         raise HTTPException(403, 'You don\'t have the required permission to access the flight')
     
-    await delete_flight_by_id(flight_id)
-
+    result = await bulk_delete_flights_by_ids([flight_id])
+    if not result:
+        raise HTTPException(500, 'Failed to delete flight')
     return 'success'

--- a/app/controller/vessel_controller.py
+++ b/app/controller/vessel_controller.py
@@ -15,7 +15,7 @@ from app.services.auth.jwt_user_info import get_socket_user_info
 from app.services.auth.permission_service import has_vessel_permission, modify_vessel_permission
 from app.services.data_access.auth_code import create_auth_code, get_auth_codes_for_user
 from app.services.data_access.user import create_or_update_user, get_user_by_unique_name
-from app.services.data_access.vessel import create_or_update_vessel, get_all_vessels, get_vessel, get_historic_vessel, get_vessel_by_name, update_vessel_without_version_change, delete_historic_vessel
+from app.services.data_access.vessel import create_or_update_vessel, get_all_vessels, get_vessel, get_historic_vessel, get_vessel_by_name, update_vessel_without_version_change, delete_vessel_by_id
 
 vessel_controller = APIRouter(
     prefix="/vessel",
@@ -280,31 +280,10 @@ async def update_vessel(user: AuthOptional, vessel_id:UUID, vessel_update_data:U
 
     return vessel
 
-# @vessels_controller.delete("/{vessel_id}")
-# async def delete_vessel(user: AuthOptional,vessel_id:UUID) -> str:
-#     '''
-#     Deletes a vessel
-#     '''
-    
-#     vessel = await get_vessel(vessel_id)
-
-#     if vessel is None:
-#         raise HTTPException(404, 'Vessel does not exist')
-    
-#     if not has_vessel_permission(vessel, 'owner', user):
-#         raise HTTPException(403, 'You are not authorized to perform this action')
-    
-#     result = await delete_all_historic_vessels(vessel_id)
-
-#     if not result:
-#         raise HTTPException(500, 'Failed to delete vessel')
-    
-#     return 'success'
-
-@vessels_controller.delete("/{vessel_id}/versions/{version}")
-async def delete_vessel_historic_by_version_and_id(user: AuthOptional,vessel_id:UUID,version:int) -> str:
+@vessels_controller.delete("/{vessel_id}")
+async def delete_vessel(user: AuthOptional,vessel_id:UUID) -> str:
     '''
-    Deletes a historic version of a vessel
+    Deletes a vessel
     '''
     
     vessel = await get_vessel(vessel_id)
@@ -315,13 +294,7 @@ async def delete_vessel_historic_by_version_and_id(user: AuthOptional,vessel_id:
     if not has_vessel_permission(vessel, 'owner', user):
         raise HTTPException(403, 'You are not authorized to perform this action')
     
-    if vessel.version != version:
-        vessel = await get_historic_vessel(vessel_id, version)
-    
-    if vessel is None:
-        raise HTTPException(404, 'Vessel does not exist')
-
-    result = await delete_historic_vessel(vessel_id, version)
+    result = await delete_vessel_by_id(vessel_id)
 
     if not result:
         raise HTTPException(500, 'Failed to delete vessel')

--- a/app/controller/vessel_controller.py
+++ b/app/controller/vessel_controller.py
@@ -16,6 +16,7 @@ from app.services.auth.permission_service import has_vessel_permission, modify_v
 from app.services.data_access.auth_code import create_auth_code, get_auth_codes_for_user
 from app.services.data_access.user import create_or_update_user, get_user_by_unique_name
 from app.services.data_access.vessel import create_or_update_vessel, get_all_vessels, get_vessel, get_historic_vessel, get_vessel_by_name, update_vessel_without_version_change, delete_vessel_by_id
+from app.services.vessel_service import VesselService
 
 vessel_controller = APIRouter(
     prefix="/vessel",
@@ -294,7 +295,7 @@ async def delete_vessel(user: AuthOptional,vessel_id:UUID) -> str:
     if not has_vessel_permission(vessel, 'owner', user):
         raise HTTPException(403, 'You are not authorized to perform this action')
     
-    result = await delete_vessel_by_id(vessel_id)
+    result = await VesselService.delete_vessel(vessel_id)
 
     if not result:
         raise HTTPException(500, 'Failed to delete vessel')

--- a/app/services/data_access/flight.py
+++ b/app/services/data_access/flight.py
@@ -56,20 +56,10 @@ async def get_flight(_id: UUID) -> Union[Flight, None]:
 
     return None
 
+
 async def bulk_delete_flights_by_ids(_ids: List[UUID]) -> bool:
     flight_collection = get_flight_collection()
-    flight_data_collection = await get_or_init_flight_data_collection("flight_data")
-    commands_collection = await get_or_init_flight_data_collection("commands")
-
-    results = await asyncio.gather(
-        flight_data_collection.delete_many({'metadata._flight_id': {'$in': _ids}}),
-        commands_collection.delete_many({'metadata._flight_id': {'$in': _ids}}),
-        flight_collection.delete_many({'_id': {'$in': _ids}})
-    )
-
-    return results[2].deleted_count > 0
+    results = await flight_collection.delete_many({'_id': {'$in': _ids}})
     
+    return results.deleted_count > 0
 
-
-
-    

--- a/app/services/data_access/flight_data.py
+++ b/app/services/data_access/flight_data.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Literal, Sequence, cast
+from typing import Any, List, Literal, Sequence, cast
 from uuid import UUID
 from motor.core import AgnosticCollection, AgnosticDatabase
 from pymongo import ASCENDING, DESCENDING
@@ -193,3 +193,17 @@ async def get_aggregated_flight_data(flight_id: UUID, part_index: int | None, me
         del m['_id']
             
     return [FlightMeasurementAggregated(**r) for r in res]
+
+async def bulk_delete_flight_data_by_flight_ids(_ids: List[UUID]) -> bool:
+    flight_data_collection = await get_or_init_flight_data_collection("flight_data")
+    results = await flight_data_collection.delete_many({'metadata._flight_id': {'$in': _ids}})
+    
+    return results.deleted_count > 0
+
+async def bulk_delete_flight_commands_by_flight_ids(_ids: List[UUID]) -> bool:
+    commands_collection = await get_or_init_flight_data_collection("commands")  
+    results = await commands_collection.delete_many({'metadata._flight_id': {'$in': _ids}})
+
+    return results.deleted_count > 0
+        
+    

--- a/app/services/data_access/flight_data.py
+++ b/app/services/data_access/flight_data.py
@@ -109,6 +109,7 @@ async def insert_flight_data(measurements: list[FlightMeasurementDB], flight_id:
 
     # current_app.logger.debug(f'Pushed {len(measurements)} compact measurements. Total: {int((preparation_time + db_time)*1000)}ms; Preparation {int((preparation_time)*1000)}ms; DB: {int((db_time)*1000)}ms;')
 
+
 async def get_flight_data_in_range(series_identifier: FlightMeasurementSeriesIdentifier, start: datetime, end: datetime, table: str = 'flight_data') -> list[FlightMeasurementDB]:
     collection = await get_or_init_flight_data_collection(table)
 

--- a/app/services/data_access/vessel.py
+++ b/app/services/data_access/vessel.py
@@ -1,10 +1,12 @@
 import json
-from typing import Union, cast
+from typing import Union
 from uuid import UUID
 from motor.core import AgnosticCollection
 
 from app.models.vessel import Vessel, VesselHistoric, VesselHistoricKey
+from app.services.data_access.flight import bulk_delete_flights_by_ids, get_all_flights_for_vessels
 from .mongodb.mongodb_connection import get_db
+import asyncio
 
 def get_vessel_collection() -> AgnosticCollection:
     db = get_db()
@@ -93,12 +95,30 @@ async def get_historic_vessel(_id: UUID, _version: int):
 
     return None
 
-async def delete_vessel_by_id(_id:UUID):
+async def delete_vessel_by_id(_id:UUID) -> bool:
+    """
+    Deleting a vessel by id deletes the vessel, it's historic versions, 
+    all flights associated with it and all data with those flights, including flight measurements and commands
+    """
     vessel_collection = get_vessel_collection()
-    
-    result = await vessel_collection.delete_one({'_id': _id})
 
-    return result.deleted_count > 0
+    # Get all flights associated with the vessel
+    flights = await get_all_flights_for_vessels(_id)
+    flight_ids = [flight.id for flight in flights]
+
+    if flight_ids:
+        results = await asyncio.gather(
+            bulk_delete_flights_by_ids(flight_ids),
+            delete_all_historic_vessels(_id),
+            vessel_collection.delete_one({'_id': _id})
+        )
+    else:
+        results = await asyncio.gather(
+            delete_all_historic_vessels(_id),
+            vessel_collection.delete_one({'_id': _id})
+        )
+    return results[-1].deleted_count > 0
+
 
 async def delete_historic_vessel(_id:UUID, _version:int):
     vessel_collection = get_historic_vessel_collection()

--- a/app/services/flight_service.py
+++ b/app/services/flight_service.py
@@ -1,0 +1,18 @@
+import asyncio
+from typing import List
+from uuid import UUID
+
+from app.services.data_access.flight import bulk_delete_flights_by_ids
+from app.services.data_access.flight_data import bulk_delete_flight_commands_by_flight_ids, bulk_delete_flight_data_by_flight_ids
+
+
+class FlightService:
+    @staticmethod
+    async def bulk_delete_flights_by_ids(_ids: List[UUID]) -> bool:
+        results = await asyncio.gather(
+            bulk_delete_flight_data_by_flight_ids(_ids),
+            bulk_delete_flight_commands_by_flight_ids(_ids),
+            bulk_delete_flights_by_ids(_ids)
+        )
+
+        return results[2]

--- a/app/services/vessel_service.py
+++ b/app/services/vessel_service.py
@@ -1,0 +1,23 @@
+import asyncio
+from typing import List
+from uuid import UUID
+
+from app.services.data_access.flight import bulk_delete_flights_by_ids, get_all_flights_for_vessels
+from app.services.data_access.flight_data import bulk_delete_flight_commands_by_flight_ids, bulk_delete_flight_data_by_flight_ids
+from app.services.data_access.vessel import delete_vessel_by_id
+from app.services.flight_service import FlightService
+
+
+class VesselService:
+    @staticmethod
+    async def delete_vessel(_id: UUID) -> bool:
+        flights = await get_all_flights_for_vessels(_id)
+        flight_ids = [flight.id for flight in flights]
+
+        results = await asyncio.gather(
+            FlightService.bulk_delete_flights_by_ids(flight_ids),
+            delete_vessel_by_id(_id),
+        )
+
+        return results[1]
+        

--- a/tests/api/original/flight/test_create_flight.py
+++ b/tests/api/original/flight/test_create_flight.py
@@ -22,7 +22,7 @@ async def test_create_flight(test_client:TestClient,test_user_bearer):
     vessel = create_vessel_response.json()
     
     # Get Auth code for the vessel hardware to register with
-    valid_until = datetime.now(timezone.utc) + timedelta(minutes=1)
+    valid_until = datetime.now(timezone.utc) + timedelta(1)
     auth_code_response = test_client.post(f"/vessel/create_auth_code/{vessel['_id']}/{valid_until}",headers=get_auth_headers(bearer))
     assert auth_code_response.status_code == 200
     auth_code = auth_code_response.json()['_id']

--- a/tests/api/v1/flight/test_create_flight.py
+++ b/tests/api/v1/flight/test_create_flight.py
@@ -30,7 +30,7 @@ async def test_v1_create_flight(test_client:TestClient,test_user_bearer):
     vessel = create_vessel_response.json()
     
     # Get Auth code for the vessel hardware to register with
-    valid_until = datetime.now(timezone.utc) + timedelta(minutes=1)
+    valid_until = datetime.now(timezone.utc) + timedelta(1)
 
     auth_code_data = {
         'valid_until': valid_until.isoformat()

--- a/tests/api/v1/vessel/test_delete_vessel.py
+++ b/tests/api/v1/vessel/test_delete_vessel.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from uuid import uuid4
+from uuid import UUID, uuid4
 from tests.auth_helper import get_auth_headers
 from tests.conftest import TEST_USER_UUID
 from typing import Any
@@ -11,10 +11,15 @@ from datetime import timezone
 import jwt
 from app.models.vessel_part import VesselPart
 
+from app.services.data_access.mongodb.mongodb_connection import get_db
+import copy
+
 
 @pytest.mark.asyncio
-async def test_v1_delete_vessel_historic(test_client: TestClient, test_user_bearer):
+async def test_v1_delete_vessel(test_client: TestClient, test_user_bearer):
     bearer = await test_user_bearer
+    uuid_1 = UUID('a6c9efe6-bf2a-47bc-aecd-f911ed3d30d1')
+    flight_collection = get_db()['flights']
     
     vessel = test_client.post(
         f'/v1/vessels/',
@@ -23,7 +28,7 @@ async def test_v1_delete_vessel_historic(test_client: TestClient, test_user_bear
     ).json()
 
     # Get Auth code for the vessel hardware to register with
-    valid_until = datetime.now(timezone.utc) + timedelta(minutes=1)
+    valid_until = datetime.now(timezone.utc) + timedelta(1)
 
     auth_code_data = {
         'valid_until': valid_until.isoformat()
@@ -65,11 +70,13 @@ async def test_v1_delete_vessel_historic(test_client: TestClient, test_user_bear
     assert registered_vessel['name'] == 'Original Vessel'
     assert registered_vessel['_version'] == 1
 
+    vessel_version_1 = copy.deepcopy(registered_vessel)
+
     vessel_part = VesselPart(
         name='Test Part',
         part_type='Test Type',
         virtual=True,
-        _id = uuid4()
+        _id = uuid_1
     )
 
     # Add a part to the vessel
@@ -87,13 +94,66 @@ async def test_v1_delete_vessel_historic(test_client: TestClient, test_user_bear
     )
 
     registered_vessel = register_vessel_response.json()
+
     assert register_vessel_response.status_code == 200
     assert registered_vessel['name'] == 'Original Vessel'
     assert registered_vessel['_version'] == 2
 
+    vessel_version_2 = copy.deepcopy(registered_vessel)
+
+    get_response = test_client.get(
+        f"/v1/vessels/{vessel['_id']}/versions/1",
+        headers=get_auth_headers(bearer)
+    )
+
+    assert get_response.status_code == 200
+
+    # Version 2 should still exist
+    get_response = test_client.get(
+        f"/v1/vessels/{vessel['_id']}/versions/2",
+        headers=get_auth_headers(bearer)
+    )
+
+    # Create a test flight for this vessel
+    now = datetime.now(timezone.utc)
+    first_flight = {
+        "start":now.isoformat(),
+        "_vessel_id":vessel['_id'],
+        "_vessel_version":vessel['_version'],
+        "name":'Test Flight',
+        "measured_parts": {},
+        "measured_part_ids":[],
+        "available_commands":{}
+    }
+
+    create_flight_response = test_client.post('/v1/flights/', 
+        json=first_flight, 
+        headers=get_auth_headers(vessel_bearer_token))
+
+    assert create_flight_response.status_code == 200
+    create_flight_data = create_flight_response.json()
+    assert '_id' in create_flight_data
+    assert create_flight_data['_vessel_id'] == vessel['_id']
+    print(create_flight_data)
+    assert get_response.status_code == 200
+
+    flight_response = test_client.get(f"/v1/vessels/{vessel['_id']}/flights", 
+       headers=get_auth_headers(bearer)
+    )
+
+    assert flight_response.status_code == 200
+    flight_data = flight_response.json()
+    print(vessel["_id"])
+    print(flight_data)
+    assert len(flight_data) == 1
+
+    raw = await flight_collection.find({'_vessel_id': UUID(vessel["_id"]) }).to_list(1000) 
+
+    assert len(raw) == 1
+
     # Delete the original
     delete_response = test_client.delete(
-        f"/v1/vessels/{vessel['_id']}/versions/1",
+        f"/v1/vessels/{vessel['_id']}",
         headers=get_auth_headers(bearer)
     )
 
@@ -107,10 +167,23 @@ async def test_v1_delete_vessel_historic(test_client: TestClient, test_user_bear
     )
     assert get_response.status_code == 404
 
-    # Version 2 should still exist
     get_response = test_client.get(
         f"/v1/vessels/{vessel['_id']}/versions/2",
         headers=get_auth_headers(bearer)
     )
+    assert get_response.status_code == 404
 
-    assert get_response.status_code == 200
+    flight_response = test_client.get(f"/v1/vessels/{vessel['_id']}/flights", 
+       headers=get_auth_headers(bearer)
+    )
+
+    # Vessel shouldn't exist
+    assert flight_response.status_code == 400
+
+    # The flight should be deleted from the DB
+    raw = await flight_collection.find({'_vessel_id': UUID(vessel["_id"]) }).to_list(1000) 
+    assert len(raw) == 0
+
+
+
+    


### PR DESCRIPTION
Deleting flights:
- delete flight data associated
- delete commands associated
- delete the flight itself

Deleting vessels
- delete all flights of the vessel as above
- delete historic versions
- delete the vessel

I have tests included in the PR for this, the tests dont cover the flight data and commands however if you could take a look at the code in ```app/services/flight.py``` that does the deleting to sense check it.

I've pasted below for ease

```python
async def bulk_delete_flights_by_ids(_ids: List[UUID]) -> bool:
    flight_collection = get_flight_collection()
    flight_data_collection = await get_or_init_flight_data_collection("flight_data")
    commands_collection = await get_or_init_flight_data_collection("commands")

    results = await asyncio.gather(
        flight_data_collection.delete_many({'metadata._flight_id': {'$in': _ids}}),
        commands_collection.delete_many({'metadata._flight_id': {'$in': _ids}}),
        flight_collection.delete_many({'_id': {'$in': _ids}})
    )

    return results[2].deleted_count > 0
    
```